### PR TITLE
c++: code fix use "!= nullptr" instead of "> 0"

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -2160,7 +2160,7 @@ namespace tools {
 			int pos = 0;
 			for (int i = 0; i < (int)strlen(input); i++) {
 				char c = input[i];
-				if (strchr("<>&\"'", c) > 0) {
+				if (strchr("<>&\"'", c) != nullptr) {
 					strncpy(output + pos,
 						c == '<' ? "&#60;" :
 						c == '>' ? "&#62;" :


### PR DESCRIPTION
My GCC 12.1 compiler complained about this line of code.
I am a C programmer working on improving my C++ knowledge; I think I fixed it correctly.

Tim S. 