### PR TITLE
Add missing switch break after WM_COMMAND

### DIFF
--- a/src/dialogs.cpp
+++ b/src/dialogs.cpp
@@ -5825,6 +5825,7 @@ namespace dialogs {
 					DeleteObject(hBitmap);
 				}
 			}
+			break;
 
 			case WM_LBUTTONDOWN: {
 				SetFocus(hWnd);


### PR DESCRIPTION
GCC warns about this, which is how I noticed.